### PR TITLE
Improve auth error messaging and clean up unused import

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -19,11 +19,11 @@ export default function AuthCallbackPage() {
       try {
         // Get the code from the URL
         const code = searchParams.get('code');
-        const error = searchParams.get('error');
+        const authError = searchParams.get('error');
         const errorDescription = searchParams.get('error_description');
 
-        if (error) {
-          setError(errorDescription || error);
+        if (authError) {
+          setError(errorDescription || authError);
           return;
         }
 
@@ -42,12 +42,14 @@ export default function AuthCallbackPage() {
           setError(t('noCodeError'));
         }
       } catch (err) {
-        setError(t('unexpectedError'));
+        const fallbackMessage = t('unexpectedError');
+        const message = err instanceof Error && err.message ? err.message : fallbackMessage;
+        setError(message);
       }
     };
 
     handleCallback();
-  }, [router, searchParams]);
+  }, [router, searchParams, t]);
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -35,7 +35,9 @@ export default function LoginPage() {
         window.location.href = '/decks';
       }
     } catch (err) {
-      setError(t('unexpectedError'));
+      const fallbackMessage = t('unexpectedError');
+      const message = err instanceof Error && err.message ? err.message : fallbackMessage;
+      setError(message);
       setLoading(false);
     }
   };

--- a/src/app/auth/reset/page.tsx
+++ b/src/app/auth/reset/page.tsx
@@ -33,7 +33,9 @@ export default function ResetPasswordPage() {
         setSuccess(true);
       }
     } catch (err) {
-      setError(t('unexpectedError'));
+      const fallbackMessage = t('unexpectedError');
+      const message = err instanceof Error && err.message ? err.message : fallbackMessage;
+      setError(message);
     } finally {
       setLoading(false);
     }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -52,7 +52,9 @@ export default function SignupPage() {
         setTimeout(() => router.push('/auth/login'), 2000);
       }
     } catch (err) {
-      setError(t('unexpectedError'));
+      const fallbackMessage = t('unexpectedError');
+      const message = err instanceof Error && err.message ? err.message : fallbackMessage;
+      setError(message);
     } finally {
       setLoading(false);
     }

--- a/src/features/stats/hooks/use-progress.ts
+++ b/src/features/stats/hooks/use-progress.ts
@@ -8,7 +8,6 @@ import {
   getDeckAnalytics,
   resetDeckProgress,
 } from '@/lib/db';
-import type { Progress } from '@/lib/types';
 
 /**
  * Hook to fetch progress for a specific card


### PR DESCRIPTION
## Summary
- show server-provided error messages with a translated fallback across auth pages
- handle Supabase callback errors more clearly and ensure the effect depends on the translation helper
- remove an unused Progress type import from the stats progress hook

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130769d4dc832eb923c377d5e313f3)