### PR TITLE
Localize confirm dialog strings

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -82,6 +82,28 @@
 		},
 		"cta": "Start Learning Today"
 	},
+	"ConfirmDialog": {
+		"confirm": "Confirm",
+		"cancel": "Cancel",
+		"deleteDeck": {
+			"title": "Delete Deck",
+			"message": "Are you sure you want to delete \"{deckName}\"? This action cannot be undone and all cards in this deck will be permanently deleted.",
+			"confirm": "Delete Deck",
+			"cancel": "Keep Deck"
+		},
+		"deleteCard": {
+			"title": "Delete Card",
+			"message": "Are you sure you want to delete this card: \"{cardQuestion}\"? This action cannot be undone.",
+			"confirm": "Delete Card",
+			"cancel": "Keep Card"
+		},
+		"resetProgress": {
+			"title": "Reset Progress",
+			"message": "Are you sure you want to reset all learning progress for \"{deckName}\"? All cards will be marked as new and need to be studied again.",
+			"confirm": "Reset Progress",
+			"cancel": "Keep Progress"
+		}
+	},
 	"PrivacyPage": {
 		"title": "Privacy Policy",
 		"subtitle": "Your privacy is important to us",

--- a/languages/es.json
+++ b/languages/es.json
@@ -82,6 +82,28 @@
 		},
 		"cta": "Comienza a Aprender Hoy"
 	},
+	"ConfirmDialog": {
+		"confirm": "Confirmar",
+		"cancel": "Cancelar",
+		"deleteDeck": {
+			"title": "Eliminar Mazo",
+			"message": "¿Seguro que quieres eliminar \"{deckName}\"? Esta acción no se puede deshacer y todas las tarjetas de este mazo se eliminarán permanentemente.",
+			"confirm": "Eliminar Mazo",
+			"cancel": "Mantener Mazo"
+		},
+		"deleteCard": {
+			"title": "Eliminar Tarjeta",
+			"message": "¿Seguro que quieres eliminar esta tarjeta: \"{cardQuestion}\"? Esta acción no se puede deshacer.",
+			"confirm": "Eliminar Tarjeta",
+			"cancel": "Mantener Tarjeta"
+		},
+		"resetProgress": {
+			"title": "Restablecer Progreso",
+			"message": "¿Seguro que quieres restablecer todo el progreso de aprendizaje de \"{deckName}\"? Todas las tarjetas se marcarán como nuevas y tendrás que estudiarlas de nuevo.",
+			"confirm": "Restablecer Progreso",
+			"cancel": "Mantener Progreso"
+		}
+	},
 	"PrivacyPage": {
 		"title": "Política de Privacidad",
 		"subtitle": "Tu privacidad es importante para nosotros",

--- a/languages/sv.json
+++ b/languages/sv.json
@@ -82,6 +82,28 @@
 		},
 		"cta": "Börja Lära Dig Idag"
 	},
+	"ConfirmDialog": {
+		"confirm": "Bekräfta",
+		"cancel": "Avbryt",
+		"deleteDeck": {
+			"title": "Ta bort kortlek",
+			"message": "Är du säker på att du vill ta bort \"{deckName}\"? Denna åtgärd kan inte ångras och alla kort i denna kortlek kommer att tas bort permanent.",
+			"confirm": "Ta bort kortlek",
+			"cancel": "Behåll kortlek"
+		},
+		"deleteCard": {
+			"title": "Ta bort kort",
+			"message": "Är du säker på att du vill ta bort det här kortet: \"{cardQuestion}\"? Denna åtgärd kan inte ångras.",
+			"confirm": "Ta bort kort",
+			"cancel": "Behåll kort"
+		},
+		"resetProgress": {
+			"title": "Återställ framsteg",
+			"message": "Är du säker på att du vill återställa allt inlärningsframsteg för \"{deckName}\"? Alla kort kommer att markeras som nya och behöver studeras igen.",
+			"confirm": "Återställ framsteg",
+			"cancel": "Behåll framsteg"
+		}
+	},
 	"PrivacyPage": {
 		"title": "Integritetspolicy",
 		"subtitle": "Din integritet är viktig för oss",

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
 import {
 	Dialog,
 	DialogContent,
@@ -25,17 +26,21 @@ interface ConfirmDialogProps {
 }
 
 export default function ConfirmDialog({
-	isOpen,
-	title,
-	message,
-	confirmLabel = 'Confirm',
-	cancelLabel = 'Cancel',
-	variant = 'danger',
-	onConfirm,
-	onCancel,
-	className = ''
+        isOpen,
+        title,
+        message,
+        confirmLabel,
+        cancelLabel,
+        variant = 'danger',
+        onConfirm,
+        onCancel,
+        className = ''
 }: ConfirmDialogProps) {
-	const confirmButtonRef = useRef<HTMLButtonElement>(null);
+        const confirmButtonRef = useRef<HTMLButtonElement>(null);
+        const t = useTranslations('ConfirmDialog');
+
+        const finalConfirmLabel = confirmLabel ?? t('confirm');
+        const finalCancelLabel = cancelLabel ?? t('cancel');
 
 	// Focus management
 	useEffect(() => {
@@ -84,94 +89,102 @@ export default function ConfirmDialog({
 					</div>
 				</DialogHeader>
 				<DialogFooter className="gap-2">
-					<Button variant="outline" onClick={onCancel}>
-						{cancelLabel}
-					</Button>
-					<Button
-						ref={confirmButtonRef}
-						variant={variant === 'danger' ? 'destructive' : 'default'}
-						onClick={onConfirm}
-					>
-						{confirmLabel}
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
-	);
+                                        <Button variant="outline" onClick={onCancel}>
+                                                {finalCancelLabel}
+                                        </Button>
+                                        <Button
+                                                ref={confirmButtonRef}
+                                                variant={variant === 'danger' ? 'destructive' : 'default'}
+                                                onClick={onConfirm}
+                                        >
+                                                {finalConfirmLabel}
+                                        </Button>
+                                </DialogFooter>
+                        </DialogContent>
+                </Dialog>
+        );
 }
 
 // Preset confirm dialogs for common actions
 export function DeleteDeckDialog({
-	isOpen,
-	deckName,
-	onConfirm,
-	onCancel
+        isOpen,
+        deckName,
+        onConfirm,
+        onCancel
 }: {
-	isOpen: boolean;
-	deckName: string;
-	onConfirm: () => void;
-	onCancel: () => void;
+        isOpen: boolean;
+        deckName: string;
+        onConfirm: () => void;
+        onCancel: () => void;
 }) {
-	return (
-		<ConfirmDialog
-			isOpen={isOpen}
-			title="Delete Deck"
-			message={`Are you sure you want to delete "${deckName}"? This action cannot be undone and all cards in this deck will be permanently deleted.`}
-			confirmLabel="Delete Deck"
-			cancelLabel="Keep Deck"
-			variant="danger"
-			onConfirm={onConfirm}
-			onCancel={onCancel}
-		/>
-	);
+        const t = useTranslations('ConfirmDialog.deleteDeck');
+
+        return (
+                <ConfirmDialog
+                        isOpen={isOpen}
+                        title={t('title')}
+                        message={t('message', { deckName })}
+                        confirmLabel={t('confirm')}
+                        cancelLabel={t('cancel')}
+                        variant="danger"
+                        onConfirm={onConfirm}
+                        onCancel={onCancel}
+                />
+        );
 }
 
 export function DeleteCardDialog({
-	isOpen,
-	cardQuestion,
-	onConfirm,
-	onCancel
+        isOpen,
+        cardQuestion,
+        onConfirm,
+        onCancel
 }: {
-	isOpen: boolean;
-	cardQuestion: string;
-	onConfirm: () => void;
-	onCancel: () => void;
+        isOpen: boolean;
+        cardQuestion: string;
+        onConfirm: () => void;
+        onCancel: () => void;
 }) {
-	return (
-		<ConfirmDialog
-			isOpen={isOpen}
-			title="Delete Card"
-			message={`Are you sure you want to delete this card: "${cardQuestion.length > 50 ? cardQuestion.substring(0, 50) + '...' : cardQuestion}"? This action cannot be undone.`}
-			confirmLabel="Delete Card"
-			cancelLabel="Keep Card"
-			variant="danger"
-			onConfirm={onConfirm}
-			onCancel={onCancel}
-		/>
-	);
+        const t = useTranslations('ConfirmDialog.deleteCard');
+        const truncatedQuestion =
+                cardQuestion.length > 50 ? `${cardQuestion.substring(0, 50)}...` : cardQuestion;
+
+        return (
+                <ConfirmDialog
+                        isOpen={isOpen}
+                        title={t('title')}
+                        message={t('message', { cardQuestion: truncatedQuestion })}
+                        confirmLabel={t('confirm')}
+                        cancelLabel={t('cancel')}
+                        variant="danger"
+                        onConfirm={onConfirm}
+                        onCancel={onCancel}
+                />
+        );
 }
 
 export function ResetProgressDialog({
-	isOpen,
-	deckName,
-	onConfirm,
-	onCancel
+        isOpen,
+        deckName,
+        onConfirm,
+        onCancel
 }: {
-	isOpen: boolean;
-	deckName: string;
-	onConfirm: () => void;
-	onCancel: () => void;
+        isOpen: boolean;
+        deckName: string;
+        onConfirm: () => void;
+        onCancel: () => void;
 }) {
-	return (
-		<ConfirmDialog
-			isOpen={isOpen}
-			title="Reset Progress"
-			message={`Are you sure you want to reset all learning progress for "${deckName}"? All cards will be marked as new and need to be studied again.`}
-			confirmLabel="Reset Progress"
-			cancelLabel="Keep Progress"
-			variant="warning"
-			onConfirm={onConfirm}
-			onCancel={onCancel}
-		/>
-	);
+        const t = useTranslations('ConfirmDialog.resetProgress');
+
+        return (
+                <ConfirmDialog
+                        isOpen={isOpen}
+                        title={t('title')}
+                        message={t('message', { deckName })}
+                        confirmLabel={t('confirm')}
+                        cancelLabel={t('cancel')}
+                        variant="warning"
+                        onConfirm={onConfirm}
+                        onCancel={onCancel}
+                />
+        );
 }


### PR DESCRIPTION
## Summary
- localize the reusable confirm dialog component with next-intl
- add English, Spanish, and Swedish translations for confirm dialog actions

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69144a51ab80832e88a8cd26b3b73136)