### PR TITLE
Add i18n support to global modal handler

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -323,13 +323,32 @@
 		"profile": "Profile",
 		"menu": "Menu"
 	},
-	"Footer": {
-		"about": "About",
-		"help": "Help",
-		"privacy": "Privacy",
-		"copyright": "© {year} FlashyLearny",
-		"madeWith": "Made with 💙 for learners"
-	},
+        "Footer": {
+                "about": "About",
+                "help": "Help",
+                "privacy": "Privacy",
+                "copyright": "© {year} FlashyLearny",
+                "madeWith": "Made with 💙 for learners"
+        },
+        "GlobalModalHandler": {
+                "renameDeck": {
+                        "title": "Edit Deck",
+                        "description": "Update the name and category for this deck.",
+                        "deckNameLabel": "Deck Name",
+                        "deckNamePlaceholder": "Deck name",
+                        "categoryLabel": "Category (Optional)",
+                        "categoryPlaceholder": "e.g., Languages, Science, History...",
+                        "categoryHelper": "Organize your decks by category",
+                        "cancel": "Cancel",
+                        "saving": "Saving...",
+                        "saveChanges": "Save Changes"
+                },
+                "fallbacks": {
+                        "unknownDeck": "Unknown Deck",
+                        "card": "this card",
+                        "deck": "this deck"
+                }
+        },
     "StudyCard": {
         "question": "Question",
         "answer": "Answer",

--- a/languages/es.json
+++ b/languages/es.json
@@ -323,13 +323,32 @@
 		"profile": "Perfil",
 		"menu": "Menú"
 	},
-	"Footer": {
-		"about": "Acerca de",
-		"help": "Ayuda",
-		"privacy": "Privacidad",
-		"copyright": "© {year} FlashyLearny",
-		"madeWith": "Hecho con 💙 para estudiantes"
-	},
+        "Footer": {
+                "about": "Acerca de",
+                "help": "Ayuda",
+                "privacy": "Privacidad",
+                "copyright": "© {year} FlashyLearny",
+                "madeWith": "Hecho con 💙 para estudiantes"
+        },
+        "GlobalModalHandler": {
+                "renameDeck": {
+                        "title": "Editar mazo",
+                        "description": "Actualiza el nombre y la categoría de este mazo.",
+                        "deckNameLabel": "Nombre del mazo",
+                        "deckNamePlaceholder": "Nombre del mazo",
+                        "categoryLabel": "Categoría (opcional)",
+                        "categoryPlaceholder": "p. ej., Idiomas, Ciencia, Historia...",
+                        "categoryHelper": "Organiza tus mazos por categoría",
+                        "cancel": "Cancelar",
+                        "saving": "Guardando...",
+                        "saveChanges": "Guardar cambios"
+                },
+                "fallbacks": {
+                        "unknownDeck": "Mazo desconocido",
+                        "card": "esta tarjeta",
+                        "deck": "este mazo"
+                }
+        },
     "StudyCard": {
         "question": "Pregunta",
         "answer": "Respuesta",

--- a/languages/sv.json
+++ b/languages/sv.json
@@ -323,13 +323,32 @@
 		"profile": "Profil",
 		"menu": "Meny"
 	},
-	"Footer": {
-		"about": "Om",
-		"help": "Hjälp",
-		"privacy": "Integritet",
-		"copyright": "© {year} FlashyLearny",
-		"madeWith": "Gjord med 💙 för elever"
-	},
+        "Footer": {
+                "about": "Om",
+                "help": "Hjälp",
+                "privacy": "Integritet",
+                "copyright": "© {year} FlashyLearny",
+                "madeWith": "Gjord med 💙 för elever"
+        },
+        "GlobalModalHandler": {
+                "renameDeck": {
+                        "title": "Redigera kortlek",
+                        "description": "Uppdatera namn och kategori för den här kortleken.",
+                        "deckNameLabel": "Kortleksnamn",
+                        "deckNamePlaceholder": "Kortleksnamn",
+                        "categoryLabel": "Kategori (valfritt)",
+                        "categoryPlaceholder": "t.ex. Språk, Vetenskap, Historia...",
+                        "categoryHelper": "Organisera dina kortlekar efter kategori",
+                        "cancel": "Avbryt",
+                        "saving": "Sparar...",
+                        "saveChanges": "Spara ändringar"
+                },
+                "fallbacks": {
+                        "unknownDeck": "Okänd kortlek",
+                        "card": "det här kortet",
+                        "deck": "den här kortleken"
+                }
+        },
     "StudyCard": {
         "question": "Fråga",
         "answer": "Svar",

--- a/src/components/GlobalModalHandler.tsx
+++ b/src/components/GlobalModalHandler.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { useUIStore } from '@/stores/ui';
 import { useDeleteDeck, useDeleteCard, useResetDeckProgress, useUpdateDeck } from '@/hooks';
 import { DeleteDeckDialog, DeleteCardDialog, ResetProgressDialog } from './ConfirmDialog';
@@ -16,8 +17,9 @@ import { Button } from './ui/button';
  * This component is rendered once at the app level and handles modal state
  */
 export default function GlobalModalHandler() {
-	const router = useRouter();
-	const { modal, closeModal } = useUIStore();
+        const t = useTranslations('GlobalModalHandler');
+        const router = useRouter();
+        const { modal, closeModal } = useUIStore();
 	const deleteDeckMutation = useDeleteDeck();
 	const deleteCardMutation = useDeleteCard();
 	const updateDeckMutation = useUpdateDeck();
@@ -88,76 +90,76 @@ export default function GlobalModalHandler() {
 
 	// Render appropriate modal based on type
 	switch (modal.type) {
-		case 'deleteDeck':
-			return (
-				<DeleteDeckDialog
-					isOpen={modal.isOpen}
-					deckName={modal.data?.deckName as string || 'Unknown Deck'}
-					onConfirm={handleDeleteDeck}
-					onCancel={closeModal}
-				/>
-			);
+                case 'deleteDeck':
+                        return (
+                                <DeleteDeckDialog
+                                        isOpen={modal.isOpen}
+                                        deckName={modal.data?.deckName as string || t('fallbacks.unknownDeck')}
+                                        onConfirm={handleDeleteDeck}
+                                        onCancel={closeModal}
+                                />
+                        );
 
-		case 'deleteCard':
-			return (
-				<DeleteCardDialog
-					isOpen={modal.isOpen}
-					cardQuestion={modal.data?.cardQuestion as string || 'this card'}
-					onConfirm={handleDeleteCard}
-					onCancel={closeModal}
-				/>
-			);
+                case 'deleteCard':
+                        return (
+                                <DeleteCardDialog
+                                        isOpen={modal.isOpen}
+                                        cardQuestion={modal.data?.cardQuestion as string || t('fallbacks.card')}
+                                        onConfirm={handleDeleteCard}
+                                        onCancel={closeModal}
+                                />
+                        );
 
-		case 'resetProgress':
-			return (
-				<ResetProgressDialog
-					isOpen={modal.isOpen}
-					deckName={(modal.data?.deckName as string) || 'this deck'}
-					onConfirm={handleResetProgress}
-					onCancel={closeModal}
-				/>
-			);
+                case 'resetProgress':
+                        return (
+                                <ResetProgressDialog
+                                        isOpen={modal.isOpen}
+                                        deckName={(modal.data?.deckName as string) || t('fallbacks.deck')}
+                                        onConfirm={handleResetProgress}
+                                        onCancel={closeModal}
+                                />
+                        );
 
-		case 'renameDeck':
-			return (
-				<Dialog open={modal.isOpen} onOpenChange={(open) => !open && closeModal()}>
-					<DialogContent>
-						<DialogHeader>
-							<DialogTitle>Edit Deck</DialogTitle>
-							<DialogDescription>Update the name and category for this deck.</DialogDescription>
-						</DialogHeader>
-						<div className="py-2 space-y-4">
-							<div className="space-y-2">
-								<Label htmlFor="deck-name">Deck Name</Label>
-								<Input
-									id="deck-name"
-									value={newDeckName}
-									onChange={(e) => setNewDeckName(e.target.value)}
-									placeholder="Deck name"
-								/>
-							</div>
-							<div className="space-y-2">
-								<Label htmlFor="deck-category">Category (Optional)</Label>
-								<Input
-									id="deck-category"
-									value={newCategory}
-									onChange={(e) => setNewCategory(e.target.value)}
-									placeholder="e.g., Languages, Science, History..."
-									maxLength={50}
-								/>
-								<p className="text-xs text-muted-foreground">
-									Organize your decks by category
-								</p>
-							</div>
-						</div>
-						<DialogFooter className="gap-2">
-							<Button variant="outline" onClick={closeModal}>Cancel</Button>
-							<Button onClick={handleRenameDeck} disabled={updateDeckMutation.isPending || !newDeckName.trim()}>
-								{updateDeckMutation.isPending ? 'Saving...' : 'Save Changes'}
-							</Button>
-						</DialogFooter>
-					</DialogContent>
-				</Dialog>
+                case 'renameDeck':
+                        return (
+                                <Dialog open={modal.isOpen} onOpenChange={(open) => !open && closeModal()}>
+                                        <DialogContent>
+                                                <DialogHeader>
+                                                        <DialogTitle>{t('renameDeck.title')}</DialogTitle>
+                                                        <DialogDescription>{t('renameDeck.description')}</DialogDescription>
+                                                </DialogHeader>
+                                                <div className="py-2 space-y-4">
+                                                        <div className="space-y-2">
+                                                                <Label htmlFor="deck-name">{t('renameDeck.deckNameLabel')}</Label>
+                                                                <Input
+                                                                        id="deck-name"
+                                                                        value={newDeckName}
+                                                                        onChange={(e) => setNewDeckName(e.target.value)}
+                                                                        placeholder={t('renameDeck.deckNamePlaceholder')}
+                                                                />
+                                                        </div>
+                                                        <div className="space-y-2">
+                                                                <Label htmlFor="deck-category">{t('renameDeck.categoryLabel')}</Label>
+                                                                <Input
+                                                                        id="deck-category"
+                                                                        value={newCategory}
+                                                                        onChange={(e) => setNewCategory(e.target.value)}
+                                                                        placeholder={t('renameDeck.categoryPlaceholder')}
+                                                                        maxLength={50}
+                                                                />
+                                                                <p className="text-xs text-muted-foreground">
+                                                                        {t('renameDeck.categoryHelper')}
+                                                                </p>
+                                                        </div>
+                                                </div>
+                                                <DialogFooter className="gap-2">
+                                                        <Button variant="outline" onClick={closeModal}>{t('renameDeck.cancel')}</Button>
+                                                        <Button onClick={handleRenameDeck} disabled={updateDeckMutation.isPending || !newDeckName.trim()}>
+                                                                {updateDeckMutation.isPending ? t('renameDeck.saving') : t('renameDeck.saveChanges')}
+                                                        </Button>
+                                                </DialogFooter>
+                                        </DialogContent>
+                                </Dialog>
 			);
 
 		case 'paywall':


### PR DESCRIPTION
## Summary
- integrate next-intl translations into the global modal handler modal flows
- add rename deck modal copy and fallback strings to the English, Spanish, and Swedish locale files

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145f86f8b0832e8ad833869638e194)